### PR TITLE
Change recording srv type; Add 1hz recording status publish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,9 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(OpenCV REQUIRED)
 
-add_service_files(
-  FILES
-  StartRecording.srv
-  StopRecording.srv
-)
+# add_service_files(
+#   FILES
+# )
 
 generate_messages(
   DEPENDENCIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   sensor_msgs
   std_msgs
+  std_srvs
   cv_bridge
   image_transport
   message_generation

--- a/include/camera_rospkg/camera_publisher.h
+++ b/include/camera_rospkg/camera_publisher.h
@@ -2,6 +2,8 @@
 #define PHYSICAL_CAMERA_H
 
 #include <ros/ros.h>
+#include <std_msgs/Bool.h>
+#include <std_srvs/Trigger.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/Image.h>
@@ -14,6 +16,7 @@ class CameraPublisher {
 public:
     CameraPublisher(ros::NodeHandle& nh);
     void publishImage();
+    void publishRecordingStatus();
 
 private:
     ros::NodeHandle nh_;
@@ -39,8 +42,10 @@ private:
 
     ros::ServiceServer start_recording_srv_;
     ros::ServiceServer stop_recording_srv_;
-    bool startRecordingCallback(camera_rospkg::StartRecording::Request &req, camera_rospkg::StartRecording::Response &res);
-    bool stopRecordingCallback(camera_rospkg::StopRecording::Request &req, camera_rospkg::StopRecording::Response &res);
+    bool startRecordingCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+    bool stopRecordingCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+
+    ros::Publisher recording_status_pub_;
 };
 
 #endif // PHYSICAL_CAMERA_H

--- a/include/camera_rospkg/camera_publisher.h
+++ b/include/camera_rospkg/camera_publisher.h
@@ -9,8 +9,6 @@
 #include <sensor_msgs/Image.h>
 #include <opencv2/opencv.hpp>
 #include <camera_rospkg/utils.h>
-#include <camera_rospkg/StartRecording.h>
-#include <camera_rospkg/StopRecording.h>
 
 class CameraPublisher {
 public:
@@ -40,10 +38,8 @@ private:
     bool is_calibration_enabled_ = false;
     void loadCameraCalibration();
 
-    ros::ServiceServer start_recording_srv_;
-    ros::ServiceServer stop_recording_srv_;
-    bool startRecordingCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
-    bool stopRecordingCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+    ros::ServiceServer on_off_recording_srv_;
+    bool OnOffRecordingCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
 
     ros::Publisher recording_status_pub_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 int main(int argc, char** argv) {
     ros::init(argc, argv, "camera_publisher");
     ros::NodeHandle nh("~");
+    ros::Time last_status_pub_time = ros::Time::now();
 
     CameraPublisher camera_publisher(nh);
 
@@ -13,6 +14,13 @@ int main(int argc, char** argv) {
     while (ros::ok()) 
     {
         camera_publisher.publishImage();
+        
+        // Publish the recording status in 1 hz
+        if (ros::Time::now() - last_status_pub_time > ros::Duration(1.0)) {
+            camera_publisher.publishRecordingStatus();
+            last_status_pub_time = ros::Time::now();
+        }
+
         loop_rate.sleep();
     }
 


### PR DESCRIPTION
### Main Changes

1. In `camera_publisher.cpp`: `StartRecording.srv` & `StopRecording.srv`  ->  one `std_srvs.Trigger` for on/off
2. In `main.cpp`: A 1hz control loop to publish recording status, `msg.data` of `std_msgs/bool` is published to `camera_publisher/recording_status`

### Changes should be made on client side

1. `ros::ServiceClient OnOffRecordingClient = nh.serviceClient<std_srvs::Trigger>("camera_publisher/on_off_recording");`
2. `res.is_sucess`  -> `res.sucess`, new `res.message` can be used to print extra info

### Tested using the following script
```
#include <ros/ros.h>
#include <std_srvs/Trigger.h>

int main(int argc, char** argv) {
    ros::init(argc, argv, "camera_client");
    ros::NodeHandle nh;

    ros::ServiceClient OnOffRecordingClient = nh.serviceClient<std_srvs::Trigger>("camera_publisher/on_off_recording");

    std_srvs::Trigger srv;

    while (ros::ok()) {
        if (OnOffRecordingClient.call(srv)) {
            if (srv.response.success) {
                ROS_INFO_STREAM(srv.response.message);
            } else {
                ROS_WARN_STREAM(srv.response.message);
            }
        } else {
            ROS_ERROR("Failed to call service");
        }
        ros::Duration(3).sleep();
    }

    return 0;
}
```
### Test result is as follow

[![Screenshot-2025-04-15-203840.png](https://i.postimg.cc/yxTXWq3n/Screenshot-2025-04-15-203840.png)](https://postimg.cc/D48bYMgb)

[![Screenshot-2025-04-15-203821.png](https://i.postimg.cc/sD7C6Tdm/Screenshot-2025-04-15-203821.png)](https://postimg.cc/Mv6LXbGf)