### PR TITLE
Fixed autostart failure by adding retry

### DIFF
--- a/launch/camera.launch.py
+++ b/launch/camera.launch.py
@@ -1,5 +1,5 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction, TimerAction
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import ComposableNodeContainer
@@ -40,14 +40,22 @@ def generate_launch_description():
         if LaunchConfiguration("autostart").perform(context).strip().lower() != "true":
             return []
 
-        configure_cmd = ExecuteProcess(
-            cmd=["ros2", "lifecycle", "set", full_node_name, "configure"], output="screen")
-        activate_cmd = ExecuteProcess(
-            cmd=["ros2", "lifecycle", "set", full_node_name, "activate"], output="screen")
+        lifecycle_cmd = (
+            f'until ros2 lifecycle set {full_node_name} configure; do '
+            'echo "Waiting for configure service..."; '
+            'sleep 1; '
+            'done; '
+            f'until ros2 lifecycle set {full_node_name} activate; do '
+            'echo "Waiting for activate service..."; '
+            'sleep 1; '
+            'done'
+        )
 
         return [
-            TimerAction(period=2.0, actions=[configure_cmd]),
-            TimerAction(period=4.0, actions=[activate_cmd]),
+            ExecuteProcess(
+                cmd=["bash", "-lc", lifecycle_cmd],
+                output="screen",
+            ),
         ]
 
     return LaunchDescription([


### PR DESCRIPTION
previously the autostart node transition was executed with single try timer based. When the transition executed before the node was created the node initialization failed. Added retry with 1s sleep. 

Extra note: We could use OnStateTransition() to only transition node status when the node is created but apparently only works if the node is standalone and not composable